### PR TITLE
fix: correct typo in research agent prompt

### DIFF
--- a/examples/research/research_agent.py
+++ b/examples/research/research_agent.py
@@ -29,7 +29,7 @@ sub_research_prompt = """You are a dedicated researcher. Your job is to conduct 
 
 Conduct thorough research and then reply to the user with a detailed answer to their question
 
-only your FINAL answer will be passed on to the user. They will have NO knowledge of anything expect your final message, so your final report should be your final message!"""
+only your FINAL answer will be passed on to the user. They will have NO knowledge of anything except your final message, so your final report should be your final message!"""
 
 research_sub_agent = {
     "name": "research-agent",


### PR DESCRIPTION
This PR corrects a small typo in the sub_research_prompt. The sentence "They will have NO knowledge of anything expect your final message" is corrected to "except your final message" to improve clarity and correctness.